### PR TITLE
Fix `Lines` type alias definition

### DIFF
--- a/src/textual/_types.py
+++ b/src/textual/_types.py
@@ -1,5 +1,5 @@
 import sys
-from typing import Awaitable, Callable, Optional, TYPE_CHECKING
+from typing import Awaitable, Callable, List, Optional, TYPE_CHECKING
 from rich.segment import Segment
 
 if sys.version_info >= (3, 8):
@@ -28,4 +28,4 @@ class EventTarget(Protocol):
 
 MessageHandler = Callable[["Message"], Awaitable]
 
-Lines = list[list[Segment]]
+Lines = List[List[Segment]]


### PR DESCRIPTION
Currently it fails with
```python
Traceback (most recent call last):
  File "~/.pyenv/versions/3.7.9/lib/python3.7/runpy.py", line 193, in _run_module_as_main
    "__main__", mod_spec)
  File "~/.pyenv/versions/3.7.9/lib/python3.7/runpy.py", line 85, in _run_code
    exec(code, run_globals)
  File "~/.virtualenvs/tmp-32ba2626ac1e0/lib/python3.7/site-packages/textual/app.py", line 18, in <module>
    from . import events
  File "~/.virtualenvs/tmp-32ba2626ac1e0/lib/python3.7/site-packages/textual/events.py", line 7, in <module>
    from .message import Message
  File "~/.virtualenvs/tmp-32ba2626ac1e0/lib/python3.7/site-packages/textual/message.py", line 7, in <module>
    from ._types import MessageTarget
  File "~/.virtualenvs/tmp-32ba2626ac1e0/lib/python3.7/site-packages/textual/_types.py", line 31, in <module>
    Lines = list[list[Segment]]
TypeError: 'type' object is not subscriptable
```