### PR TITLE
Add style attributes to renderable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [0.1.10] - Unreleased
 
+### Added
+
+- Added margin, padding, and border attributes to Widget
+
 ### Changed
 
 - Callbacks may be async or non-async.

--- a/examples/calculator.py
+++ b/examples/calculator.py
@@ -116,6 +116,7 @@ class Calculator(GridView):
 
         # The calculator display
         self.numbers = Numbers()
+        self.numbers.style_border = "bold"
 
         def make_button(text: str, style: str) -> Button:
             """Create a button with the given Figlet label."""

--- a/src/textual/geometry.py
+++ b/src/textual/geometry.py
@@ -156,11 +156,11 @@ class Region(NamedTuple):
         """Create a region from origin and size.
 
         Args:
-            origin (Point): [description]
-            size (tuple[int, int]): [description]
+            origin (Point): Origin (top left point)
+            size (tuple[int, int]): Dimensions of region.
 
         Returns:
-            Region: [description]
+            Region: A region instance.
         """
         x, y = origin
         width, height = size
@@ -171,10 +171,25 @@ class Region(NamedTuple):
 
     @property
     def x_extents(self) -> tuple[int, int]:
+        """Get the starting and ending x coord.
+
+        The end value is non inclusive.
+
+        Returns:
+            tuple[int, int]: [description]
+        """
         return (self.x, self.x + self.width)
 
     @property
     def y_extents(self) -> tuple[int, int]:
+        """Get the starting and ending x coord.
+
+        The end value is non inclusive.
+
+        Returns:
+            tuple[int, int]: [description]
+        """
+        return (self.x, self.x + self.width)
         return (self.y, self.y + self.height)
 
     @property
@@ -212,11 +227,11 @@ class Region(NamedTuple):
 
     @property
     def x_range(self) -> range:
-        return range(self.x, self.x_max)
+        return range(self.x, self.x + self.width)
 
     @property
     def y_range(self) -> range:
-        return range(self.y, self.y_max)
+        return range(self.y, self.y + self.height)
 
     def __add__(self, other: Any) -> Region:
         if isinstance(other, tuple):

--- a/src/textual/widget.py
+++ b/src/textual/widget.py
@@ -76,22 +76,18 @@ class Widget(MessagePump):
     layout_offset_y: Reactive[float] = Reactive(0.0, layout=True)
 
     style: Reactive[str | None] = Reactive(None)
-    style_padding: Reactive[PaddingDimensions | None] = Reactive(None, layout=True)
-    style_margin: Reactive[PaddingDimensions | None] = Reactive(None, layout=True)
-    style_border: Reactive[str] = Reactive("none", layout=True)
-    style_border_style: Reactive[str] = Reactive("")
-    style_border_title: Reactive[TextType] = Reactive("")
+    padding: Reactive[PaddingDimensions | None] = Reactive(None, layout=True)
+    margin: Reactive[PaddingDimensions | None] = Reactive(None, layout=True)
+    border: Reactive[str] = Reactive("none", layout=True)
+    border_style: Reactive[str] = Reactive("")
+    border_title: Reactive[TextType] = Reactive("")
 
     BOX_MAP = {"normal": box.SQUARE, "round": box.ROUNDED, "bold": box.HEAVY}
 
-    def validate_style_padding(
-        self, padding: PaddingDimensions
-    ) -> tuple[int, int, int, int]:
+    def validate_padding(self, padding: PaddingDimensions) -> tuple[int, int, int, int]:
         return Padding.unpack(padding)
 
-    def validate_style_margin(
-        self, padding: PaddingDimensions
-    ) -> tuple[int, int, int, int]:
+    def validate_margin(self, padding: PaddingDimensions) -> tuple[int, int, int, int]:
         return Padding.unpack(padding)
 
     def validate_layout_offset_x(self, value) -> int:
@@ -121,16 +117,16 @@ class Widget(MessagePump):
             RenderableType: A new renderable.
         """
         renderable = self.render()
-        if self.style_padding is not None:
-            renderable = Padding(renderable, self.style_padding)
-        if self.style_border in self.BOX_MAP:
+        if self.padding is not None:
+            renderable = Padding(renderable, self.padding)
+        if self.border in self.BOX_MAP:
             renderable = Panel(
                 renderable,
-                box=self.BOX_MAP.get(self.style_border) or box.SQUARE,
-                style=self.style_border_style,
+                box=self.BOX_MAP.get(self.border) or box.SQUARE,
+                style=self.border_style,
             )
-        if self.style_margin is not None:
-            renderable = Padding(renderable, self.style_margin)
+        if self.margin is not None:
+            renderable = Padding(renderable, self.margin)
         if self.style:
             renderable = Styled(renderable, self.style)
         return renderable

--- a/src/textual/widget.py
+++ b/src/textual/widget.py
@@ -115,6 +115,11 @@ class Widget(MessagePump):
         watch(self, attribute_name, callback)
 
     def render_styled(self) -> RenderableType:
+        """Applies style attributes to the default renderable.
+
+        Returns:
+            RenderableType: A new renderable.
+        """
         renderable = self.render()
         if self.style_padding is not None:
             renderable = Padding(renderable, self.style_padding)

--- a/src/textual/widgets/_button.py
+++ b/src/textual/widgets/_button.py
@@ -51,15 +51,16 @@ class Button(Widget):
         name: str | None = None,
         style: StyleType = "white on dark_blue",
     ):
-        self.name = name or str(label)
-        self.style = style
         super().__init__(name=name)
+        self.name = name or str(label)
+        self.button_style = style
+
         self.label = label
 
     label: Reactive[RenderableType] = Reactive("")
 
     def render(self) -> RenderableType:
-        return ButtonRenderable(self.label, style=self.style)
+        return ButtonRenderable(self.label, style=self.button_style)
 
     async def on_click(self, event: events.Click) -> None:
         await self.emit(ButtonPressed(self))


### PR DESCRIPTION
Adds style attributes to all widgets, which modify a widgets renderable.

- [x] default style
- [x] padding
- [x] margin
- [x] border

This allows any widget to be modified by setting the same attributes, for instance to draw a border around a button:

```
button.border = "round"
```


https://user-images.githubusercontent.com/554369/129796875-0a68bfa7-6f99-4c54-9642-31d9f215969c.mp4

