### PR TITLE
Fix couple of typos

### DIFF
--- a/src/textual/app.py
+++ b/src/textual/app.py
@@ -394,7 +394,7 @@ class App(MessagePump):
 
     async def on_event(self, event: events.Event) -> None:
         # Handle input events that haven't been forwarded
-        # If the event has been forwaded it may have bubbled up back to the App
+        # If the event has been forwarded it may have bubbled up back to the App
         if isinstance(event, events.InputEvent) and not event.is_forwarded:
             if isinstance(event, events.MouseEvent):
                 # Record current mouse position on App

--- a/src/textual/events.py
+++ b/src/textual/events.py
@@ -237,7 +237,7 @@ class MouseEvent(InputEvent, bubble=True):
         Args:
             sender (MessageTarget): The sender of the event.
             x (int): The relative x coordinate.
-            y (int): The relative y cootdinate.
+            y (int): The relative y coordinate.
             delta_x (int): Change in x since the last message.
             delta_y (int): Change in y since the last message.
             button (int): Indexed of the pressed button.


### PR DESCRIPTION
Fix couple of typos on:

-  `src/textual/app.py`, `forwaded` -> `forwarded`
- `src/textual/events.py`, `cootdinate` -> `coordinate`